### PR TITLE
Issue 6 percent escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     //...
-    implementation 'com.devbrackets.android:annores:1.0.0'
+    implementation 'com.devbrackets.android:annores:1.0.1'
 }
 ```
 
@@ -51,7 +51,7 @@ fun AnAnnotatedComposable() {
 
 # License
 
-    Copyright 2023 Brian Wernick
+    Copyright 2024 Brian Wernick
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/library/src/test/kotlin/com/devbrackets/android/annores/text/span/SpannedFormatterTest.kt
+++ b/library/src/test/kotlin/com/devbrackets/android/annores/text/span/SpannedFormatterTest.kt
@@ -46,6 +46,19 @@ class SpannedFormatterTest {
   }
 
   @Test
+  fun formatPercentReplacement() {
+    // Given
+    val locale = Locale("en", "us")
+    val spanned = SpannedString("%1\$d%%")
+
+    // When
+    val actual = SpannedFormatter.format(locale, spanned, 25)
+
+    // Then
+    Assert.assertEquals("25%", actual.toString())
+  }
+
+  @Test
   fun formatNewLine() {
     // Given
     val locale = Locale("en", "us")

--- a/libraryInfo.properties
+++ b/libraryInfo.properties
@@ -3,4 +3,4 @@ GROUP_ID = com.devbrackets.android
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 0
-VERSION_PATCH = 0
+VERSION_PATCH = 1


### PR DESCRIPTION
###### Fixes issue #6 
- [x] This pull request follows the coding standards

###### This PR changes:
 - Updates the version to `1.0.1`
 - Manually iterates over the regex pattern matches to ensure that we aren't missing adjacent matches. In this case the `%%` after a `%1$d` was being missed

![percent-escaped](https://github.com/brianwernick/Annores/assets/8961257/e62431e7-be1a-47ea-bd6e-ad95ee3bc8f8)
